### PR TITLE
feat: support short description

### DIFF
--- a/packages/backend/src/pr-comment-fns.ts
+++ b/packages/backend/src/pr-comment-fns.ts
@@ -31,8 +31,9 @@ export function validateEventBody(input: Partial<CommentToPrEventBody>) {
     typeof input.failedItemsCount === "number" &&
     typeof input.newItemsCount === "number" &&
     typeof input.deletedItemsCount === "number" &&
-    typeof input.passedItemsCount === "number"
-  ;
+    typeof input.passedItemsCount === "number" &&
+    (input.shortDescription == null || typeof input.shortDescription === "boolean")
+    ;
   if (!result) throw new DataValidationError(400, "invalid params");
   return true;
 }
@@ -43,6 +44,64 @@ export interface CommentSeed {
   newItemsCount: number;
   deletedItemsCount: number;
   passedItemsCount: number;
+  shortDescription?: boolean;
+}
+
+function tableItem(itemCount: number, header: string): [number, string] | null {
+  return itemCount == 0 ? null : [itemCount, header];
+}
+
+/**
+ * Returns a small table with the item counts.
+ *
+ * @example
+ * | 🔴 Changed | ⚪️ New | 🔵 Passing |
+ * | ---        | ---    | ---        |
+ * | 3          | 4      | 120        |
+ */
+function shortDescription({
+  failedItemsCount,
+  newItemsCount,
+  deletedItemsCount,
+  passedItemsCount,
+}: CommentSeed) {
+  const descriptions = [
+    tableItem(failedItemsCount, ":red_circle:  Changed"),
+    tableItem(newItemsCount, ":white_circle:  New"),
+    tableItem(deletedItemsCount, ":black_circle:  Deleted"),
+    tableItem(passedItemsCount, ":large_blue_circle:  Passing"),
+  ];
+
+  const filteredDescriptions = descriptions.filter((item): item is [number, string] => item != null);
+
+  const headerColumns = filteredDescriptions.map(([_, header]) => header);
+  const headerDelimiter = filteredDescriptions.map(() => " --- ");
+  const itemCount = filteredDescriptions.map(([itemCount]) => itemCount);
+
+  return [
+    `| ${headerColumns.join(" | ")} |`,
+    `| ${headerDelimiter.join(" | ")} |`,
+    `| ${itemCount.join(" | ")} |`,
+  ].join("\n");
+}
+
+function longDescription(eventBody: CommentSeed) {
+  const lines = [];
+  lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle:"));
+  lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle:"));
+  lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle:"));
+  lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle:"));
+  lines.push("");
+  lines.push(`<details>
+                <summary>What do the circles mean?</summary>
+                The number of circles represent the number of changed images. <br />
+                :red_circle: : Changed items,
+                :white_circle: : New items,
+                :black_circle: : Deleted items, and
+                :large_blue_circle: Passed items
+                <br />
+             </details><br />`);
+  return lines.join("\n");
 }
 
 export function createCommentBody(eventBody: CommentSeed) {
@@ -61,25 +120,18 @@ export function createCommentBody(eventBody: CommentSeed) {
       lines.push(`Check [this report](${eventBody.reportUrl}), and review them.`);
       lines.push("");
     }
-    lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle:"));
-    lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle:"));
-    lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle:"));
-    lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle:"));
-    lines.push("");
+
+    if (eventBody.shortDescription === true) {
+      lines.push(shortDescription(eventBody));
+    } else {
+      lines.push(longDescription(eventBody));
+    }
+
     lines.push(`<details>
-                  <summary>What do the circles mean?</summary>
-                  The number of circles represent the number of changed images. <br />
-                  :red_circle: : Changed items,
-                  :white_circle: : New items,
-                  :black_circle: : Deleted items, and
-                  :large_blue_circle: Passed items
-                  <br />
-               </details><br />`);
-    lines.push(`<details>
-                  <summary>How can I change the check status?</summary>
-                  If reviewers approve this PR, the reg context status will be green automatically.
-                  <br />
-               </details><br />`);
+                <summary>How can I change the check status?</summary>
+                If reviewers approve this PR, the reg context status will be green automatically.
+                <br />
+             </details><br />`);
   }
   return lines.join("\n");
 }

--- a/packages/backend/src/status-fns.test.ts
+++ b/packages/backend/src/status-fns.test.ts
@@ -22,12 +22,14 @@ describe(encodeMetadata, () => {
       newItemsCount: 11,
       deletedItemsCount: 12,
       passedItemsCount: 13,
+      shortDescription: true
     });
     expect(decodeMetadata(encoded)).toEqual({
       failedItemsCount: 10,
       newItemsCount: 11,
       deletedItemsCount: 12,
-      passedItemsCount: 13
+      passedItemsCount: 13,
+      shortDescription: true
     });
   });
 });

--- a/packages/reg-gh-app-interface/src/event-types.ts
+++ b/packages/reg-gh-app-interface/src/event-types.ts
@@ -9,6 +9,7 @@ export interface ResultMetadata {
   newItemsCount: number;
   deletedItemsCount: number;
   passedItemsCount: number;
+  shortDescription?: boolean;
 }
 
 export type PrCommentBehavior = "default" | "once" | "new";
@@ -19,6 +20,7 @@ export interface CommentToPrBody extends BaseEventBody, ResultMetadata {
   newItemsCount: number;
   deletedItemsCount: number;
   passedItemsCount: number;
+  shortDescription?: boolean;
   behavior?: PrCommentBehavior;
   reportUrl?: string;
   headOid?: string;


### PR DESCRIPTION
## What does this change?

I've ported the `shortDescription` option to `reg-notify-github-plugin`.
For backward compatibility, `shortDescription` is optional and defaults to `false`.

## References

- original PR: https://github.com/reg-viz/reg-suit/pull/207
- corresponding PR: https://github.com/reg-viz/reg-suit/pull/575
- refer: [#566](https://github.com/reg-viz/reg-suit/issues/566)

## Screenshots

- without `shortDescription`

![SCR-20220219-f76](https://user-images.githubusercontent.com/6854255/154791079-624a438b-dcc7-47ee-b5f4-3f369115c04d.png)

- with `shortDescription`

![SCR-20220219-fuv](https://user-images.githubusercontent.com/6854255/154791096-0011388c-5e08-4235-b822-6f728fff8927.png)